### PR TITLE
Fix error - "Error: Unknown command: install"

### DIFF
--- a/install
+++ b/install
@@ -85,11 +85,11 @@ pass "successfully downloaded homebrew."
 export PATH=$HOMEBREW_PREFIX/bin:$PATH
 hash -r
 
-# homebrew needs git to update.
-$HOMEBREW_PREFIX/bin/brew install git
-
 # update homebrew to latest (you'd be surprised how often this actually must be done).
 $HOMEBREW_PREFIX/bin/brew update
+
+# homebrew needs git to update.
+$HOMEBREW_PREFIX/bin/brew install git
 
 #
 # user configuration


### PR DESCRIPTION
## The Problem
- I get an error when I install homebrew-home:

``` bash
Error: Unknown command: install
```
## The Solution
- Homebrew appears to have changed - it needs a brew update before it can even install anything.
- Swapped the two lines around and it all works now
